### PR TITLE
Extend custom wire pin function for STM32

### DIFF
--- a/AS5600.cpp
+++ b/AS5600.cpp
@@ -55,6 +55,8 @@ AS5600::AS5600(TwoWire *wire)
 }
 
 
+#if defined (ESP8266) || defined(ESP32) || defined(STM32)
+
 bool AS5600::begin(int dataPin, int clockPin, uint8_t directionPin)
 {
   _directionPin = directionPin;
@@ -75,6 +77,8 @@ bool AS5600::begin(int dataPin, int clockPin, uint8_t directionPin)
   if (! isConnected()) return false;
   return true;
 }
+
+#endif
 
 
 bool AS5600::begin(uint8_t directionPin)

--- a/AS5600.cpp
+++ b/AS5600.cpp
@@ -55,8 +55,6 @@ AS5600::AS5600(TwoWire *wire)
 }
 
 
-#if defined (ESP8266) || defined(ESP32)
-
 bool AS5600::begin(int dataPin, int clockPin, uint8_t directionPin)
 {
   _directionPin = directionPin;
@@ -68,15 +66,15 @@ bool AS5600::begin(int dataPin, int clockPin, uint8_t directionPin)
 
   if ((dataPin < 255) && (clockPin < 255))
   {
-    _wire->begin(dataPin, clockPin);
+    _wire->setSDA(dataPin); 
+    _wire->setSCL(clockPin); 
+    _wire->begin();
   } else {
     _wire->begin();
   }
   if (! isConnected()) return false;
   return true;
 }
-
-#endif
 
 
 bool AS5600::begin(uint8_t directionPin)

--- a/AS5600.h
+++ b/AS5600.h
@@ -89,10 +89,9 @@ class AS5600
 public:
   AS5600(TwoWire *wire = &Wire);
 
-#if defined (ESP8266) || defined(ESP32)
   //  AS5600_SW_DIRECTION_PIN is software controlled direction pin
   bool     begin(int dataPin, int clockPin, uint8_t directionPin = AS5600_SW_DIRECTION_PIN);
-#endif
+
   bool     begin(uint8_t directionPin = AS5600_SW_DIRECTION_PIN);
   bool     isConnected();
 

--- a/AS5600.h
+++ b/AS5600.h
@@ -88,10 +88,11 @@ class AS5600
 {
 public:
   AS5600(TwoWire *wire = &Wire);
-
+  
+#if defined (ESP8266) || defined(ESP32) || defined(STM32)
   //  AS5600_SW_DIRECTION_PIN is software controlled direction pin
   bool     begin(int dataPin, int clockPin, uint8_t directionPin = AS5600_SW_DIRECTION_PIN);
-
+#endif
   bool     begin(uint8_t directionPin = AS5600_SW_DIRECTION_PIN);
   bool     isConnected();
 


### PR DESCRIPTION
Hi Rob

I was using this project to evaluate the AS5600 with an STM32 Nucleo board. Somehow the standard wire pins did not function. What i ended up with, was setting the pins explicitly which was somehow needed for my setup.

The function is secured with a now extended #ifdef.

Happy to help further tests on the STM32 platform