### PR TITLE
Added functionality to have the AS5600 on a separate shaft geared to the measured shaft

### DIFF
--- a/AS5600.h
+++ b/AS5600.h
@@ -188,15 +188,19 @@ public:
   //  READ OUTPUT REGISTERS
   uint16_t rawAngle();
   uint16_t readAngle();
+  uint16_t realAngle();
 
   //  software based offset.
+  //  degrees = -4095 .. 4095 (preferred)
+  //  returns false if abs(parameter) > 36000
+  bool     setOffset(int32_t offsetInput);
+  uint16_t getRealOffset();
   //  degrees = -359.99 .. 359.99 (preferred)
   //  returns false if abs(parameter) > 36000
   //          => expect loss of precision
   bool     setOffset(float degrees);       //  sets an absolute offset
   float    getOffset();
   bool     increaseOffset(float degrees);  //  adds to existing offset.
-
 
   //  READ STATUS REGISTERS
   uint8_t  readStatus();
@@ -234,6 +238,25 @@ public:
   //  returns last position.
   int32_t  resetCumulativePosition(int32_t position = 0);
 
+  //  EXPERIMENTAL SCALED POSITION
+  //  sets the output ratio, upduction if positive, reduction if negative.
+  //  setGearing(4) would mean the encoder will turn 4 times
+  //  per revolution of the shaft, and gearing(-4) is the inverse.
+  //  returns the old ratio.
+  int32_t  setRatio(int32_t outputRatio = 0);
+  //  get the ratio
+  int32_t  getRatio();
+  //  an extremely small min and max likely don't work well(small value untested)
+  //  returns a looped cumulative position, and updates the cumulativePosition
+  int32_t  getBoundedPosition(int32_t min, int32_t max, bool update = true);
+  //  ratio read as encoder:linked shaft
+  //  outputRatio >= 0 means outputRatio:1
+  //  works only if the sensor is read often enough.
+  float  getScaledAngle(bool update = true);
+  //  resets the cumulative position around the offset.
+  //  returns 1 if there was an error.
+  bool  zeroCumulativeToOffset();
+
   //  EXPERIMENTAL 0.5.2
   int      lastError();
 
@@ -266,6 +289,15 @@ protected:
   //  works only if the sensor is read often enough.
   int32_t  _position        = 0;
   int16_t  _lastPosition    = 0;
+
+  //  EXPERIMENTAL
+  //  allows the encoder to use a gear ratio
+  //  ratio read as encoder:linked shaft
+  //  outputRatio >= 0 means output ratio:1
+  //  must be an integer for zeroing to work correctly
+  //  works only if the sensor is read often enough.
+  //  _outputRatio < 0 means a loss of precision
+  int32_t  _outputRatio     = 0;
 };
 
 

--- a/examples/AS56000_geared_Encoder/AS5600_geared_encoder.ino
+++ b/examples/AS56000_geared_Encoder/AS5600_geared_encoder.ino
@@ -1,0 +1,67 @@
+//
+//    FILE: AS5600_geared_encoder.ino
+//  AUTHOR: Magnus Gaunt
+// PURPOSE: demo
+//     URL: https://github.com/RobTillaart/AS5600
+//
+//  Examples may use AS5600 or AS5600L devices.
+//  Check if your sensor matches the one used in the example.
+//  Optionally adjust the code.
+
+
+#include "AS5600.h"
+
+
+// Uncomment the line according to your sensor type
+AS5600L as5600;   //  use default Wire
+// AS5600 as5600;   //  use default Wire
+
+
+void setup()
+{
+  Serial.begin(115200);
+  while(!Serial);
+  Serial.println(__FILE__);
+  Serial.print("AS5600_LIB_VERSION: ");
+  Serial.println(AS5600_LIB_VERSION);
+  Serial.println();
+
+  Wire.begin();
+
+  as5600.begin(4);  //  set direction pin.
+  as5600.setDirection(AS5600_CLOCK_WISE);  //  default, just be explicit.
+
+  Serial.println(as5600.getAddress());
+
+  //  as5600.setAddress(0x40);  //  AS5600L only
+
+  int b = as5600.isConnected();
+  Serial.print("Connect: ");
+  Serial.println(b);
+
+  delay(1000);
+
+  as5600.setOffset(1000);
+  as5600.setRatio(4);
+  as5600.zeroCumulativeToOffset();
+}
+
+void loop()
+{
+  static uint32_t lastTime = 0;
+
+  as5600.getScaledAngle();
+
+  if (millis() - lastTime >= 500)
+  {
+    lastTime = millis();
+    Serial.print("the real encoder pos: ");
+    Serial.println(as5600.realAngle());
+    Serial.print("the module pos: ");
+    Serial.println(as5600.getScaledAngle());
+    Serial.println();
+  }
+}
+
+
+//  -- END OF FILE --


### PR DESCRIPTION
   All of this allows you to read the angle of a shaft that is linked to the encoder shaft at some gear ratio. This is primarily intended for low-revolution situations. For instance, you can use this on an arm. Upon calling ZeroCumulativeToOffset(), it will try to zero to the closest offset(so if you have a gear ratio of 2:1, then you only have to be within +- 90 degrees for the arm to correctly zero).

   My use case for this was driving a swerve module that was geared to the encoder; it made the encoder turn 4 times per turn of the module. The most important thing I wanted to do was make it so I didn't have to perfectly line up the module when booting, so I made these functions allow you to be within +- 180/(gear ratio). I also added functionality for the inverse gearing of that(though at a loss of precision). I don't know if this is useful to other people, but it is serving me well. I am new to software, so there might be a mistake in here. I tried my best to follow the document's "style."
   
Most of the functions added use the CumulativePositions functions, so you can't use both at the same time for separate uses.

```cpp
uint16_t realAngle(); //read non offset angle
bool  setOffset(int32_t offsetInput); //set offset with int
uint16_t getRealOffset(); //get _offset
//  EXPERIMENTAL Geared
int32_t  setRatio(int32_t outputRatio = 0);
int32_t  getRatio();
int32_t  getBoundedPosition(int32_t min, int32_t max, bool update = true);
float  getScaledAngle(bool update = true);
bool  zeroCumulativeToOffset();
```

(update readability)